### PR TITLE
Support Input Variables that contain the Seperator Charactor (I.e. Urls)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
  
   <PropertyGroup>
     <!-- edit this value to change the current MAJOR.MINOR.PATCH version -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
   </PropertyGroup>
  
   <Choose>

--- a/src/ConsoleApp/Tasks/TaskBase.cs
+++ b/src/ConsoleApp/Tasks/TaskBase.cs
@@ -19,7 +19,7 @@ namespace AlmOps.ConsoleApp.Tasks
 
             inputVariables.ForEach(x => output.Add(
                 x.Split(separator)[0],
-                x.Contains(separator) ? x.Split(separator)[1] : null));
+                x.Contains(separator) ? x.Substring(x.IndexOf(separator) + 1) : null));
 
             return output;
         }

--- a/test/ConsoleApp.UnitTests/Tasks/TaskBaseTest.cs
+++ b/test/ConsoleApp.UnitTests/Tasks/TaskBaseTest.cs
@@ -35,5 +35,19 @@ namespace AlmOps.ConsoleApp.UnitTests.Tasks
             output.Should().ContainKey("tutu");
             output["tutu"].Should().Be("tyty");
         }
+
+        [Fact]
+        public void TaskBaseGetVariables_WithSeperatorCharacter_ShouldReturnDictionary()
+        {
+            var task = new DummyTask();
+            var output = task.GetVariables(new List<string> { "connectionString:https://www.google.com", "complexPassword:Pass:Word:123" }, ":");
+            output.Should().NotBeNull();
+            output.Should().NotBeEmpty();
+            output.Count.Should().Be(2);
+            output.Should().ContainKey("connectionString");
+            output["connectionString"].Should().Be("https://www.google.com");
+            output.Should().ContainKey("complexPassword");
+            output["complexPassword"].Should().Be("Pass:Word:123");
+        }
     }
 }


### PR DESCRIPTION
Add support for Input Variables that contain the separator character ':'.
___
I was having some issues trying to use almops to update variables for automatically generated (by Pulumi) URLs and Connection Strings. Originally it would split the connection string and only store "https" in the variable group.

This update means everything after the first separate is saved in the variable group.

For example
```
almops update variables -p project --id 1 --type group --var Url:"https://www.google.com"
```
Will store `https://www.google.com` instead of `https`